### PR TITLE
close file handles

### DIFF
--- a/docs/docgen.jl
+++ b/docs/docgen.jl
@@ -23,6 +23,6 @@ function sanitizefile(filelines)
 end
 
 # generate index.md and move assets
-readme = readlines(open("../README.md"))
+readme = readlines("../README.md")
 write("src/index.md", sanitizefile(readme))
 cp("../oxygen.png", "./src/oxygen.png", force=true)

--- a/src/autodoc.jl
+++ b/src/autodoc.jl
@@ -475,7 +475,7 @@ Read in a static file from the /data folder
 """
 function readstaticfile(filepath::String) :: String 
     path = joinpath(DATA_PATH, filepath)
-    return read(open(path), String)
+    return read(path, String)
 end
 
 function redochtml() :: HTTP.Response

--- a/src/extensions/templating/mustache.jl
+++ b/src/extensions/templating/mustache.jl
@@ -37,11 +37,11 @@ function mustache(template::String; mime_type=nothing, from_file=false, kwargs..
     # Case 1: a path to a file was passed
     if from_file
         if mime_is_known
-            return mustache(open(template); mime_type=mime_type, kwargs...)
+            return open(io -> mustache(io; mime_type=mime_type, kwargs...), template)
         else
             # deterime the mime type based on the extension type 
             content_type = mime_from_path(template, MIME"application/octet-stream"()) |> contenttype_from_mime
-            return mustache(open(template); mime_type=content_type, kwargs...)
+            return open(io -> mustache(io; mime_type=content_type, kwargs...), template)
         end
     end
 
@@ -89,5 +89,3 @@ function mustache(file::IO; mime_type=nothing, kwargs...)
         response(content, status, resp_headers; detect=!mime_is_known)
     end
 end
-
-

--- a/src/extensions/templating/oteraengine.jl
+++ b/src/extensions/templating/oteraengine.jl
@@ -26,11 +26,11 @@ function otera(template::String; mime_type=nothing, from_file=false, kwargs...)
     # Case 1: a path to a file was passed
     if from_file
         if mime_is_known
-            return otera(open(template); mime_type=mime_type, kwargs...)
+            return open(io -> otera(io; mime_type=mime_type, kwargs...), template)
         else
             # deterime the mime type based on the extension type 
             content_type = mime_from_path(template, MIME"application/octet-stream"()) |> contenttype_from_mime
-            return otera(open(template); mime_type=content_type, kwargs...)
+            return open(io -> otera(io; mime_type=content_type, kwargs...), template)
         end
     end
 
@@ -72,4 +72,3 @@ function otera(file::IO; mime_type=nothing, kwargs...)
         response(content, status, resp_headers; detect=!mime_is_known)
     end
 end
-

--- a/src/utilities/fileutil.jl
+++ b/src/utilities/fileutil.jl
@@ -10,7 +10,7 @@ export readfile, mountedfolders, mountfolder
 Reads a file as a String
 """
 function readfile(filepath::String)
-    return read(open(filepath), String)
+    return read(filepath, String)
 end
 
 
@@ -95,4 +95,3 @@ function mountfolder(folder::String, mountdir::String, addroute)
     end
     
 end
-

--- a/src/utilities/render.jl
+++ b/src/utilities/render.jl
@@ -110,7 +110,7 @@ an ArgumentError is thrown. The MIME type and the size of the file are added to 
 """
 function file(filepath::String; loadfile = nothing, status = 200, headers = []) :: HTTP.Response
     has_loadfile    = !isnothing(loadfile)
-    content         = has_loadfile ? loadfile(filepath) : read(open(filepath), String)
+    content         = has_loadfile ? loadfile(filepath) : read(filepath, String)
     content_length  = has_loadfile ? string(sizeof(content)) : string(filesize(filepath))
     content_type    = mime_from_path(filepath, MIME"application/octet-stream"()) |> contenttype_from_mime
     response = HTTP.Response(status, headers, body = content)
@@ -118,4 +118,3 @@ function file(filepath::String; loadfile = nothing, status = 200, headers = []) 
     HTTP.setheader(response, "Content-Length" => content_length)
     return response
 end
-

--- a/test/templatingtests.jl
+++ b/test/templatingtests.jl
@@ -97,13 +97,13 @@ Well, 6000.0 dollars, after taxes.
 
 
         @testset "mustache() from file with no content type" begin 
-            render = mustache(open("./content/mustache_template.txt"))
+            render = open(mustache, "./content/mustache_template.txt")
             response = render(data)
             @test response.body |> String |> clean_output == expected_output
         end
 
         @testset "mustache() from file with content type" begin 
-            render = mustache(open("./content/mustache_template.txt"), mime_type="text/plain")
+            render = open(io -> mustache(io; mime_type="text/plain"), "./content/mustache_template.txt")
             response = render(data)
             @test response.body |> String |> clean_output == expected_output
         end
@@ -240,7 +240,7 @@ Well, 6000.0 dollars, after taxes.
             @test result.body |> String |> clean_output == expected_output
 
             # with explicit content type
-            render = otera(open("./content/otera_template.html"); mime_type="text/html")
+            render = open(io -> otera(io; mime_type="text/html"), "./content/otera_template.html")
             result = render(data)
             @test result.body |> String |> clean_output == expected_output
         end


### PR DESCRIPTION
I noticed usage of `open` without the function-accepting form (see the [Julia docs](https://docs.julialang.org/en/v1/base/io-network/#Base.open)). This will open a file handle, but we never close them. It's good practice to close them, see e.g. https://stackoverflow.com/a/25070939

Here I've done the minimal changes to remove unnecessary `open` calls for thing like `read` (which accept filepaths already), and in the other cases to use the form with a function as the first argument so `open` will close the handle for us.