### PR TITLE
refactor code to load modules normally

### DIFF
--- a/demo/authdemo.jl
+++ b/demo/authdemo.jl
@@ -1,7 +1,6 @@
 module AuthDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 
 @get "/divide/{a}/{b}" function(req::HTTP.Request, a::Float64, b::Float64)

--- a/demo/corsdemo.jl
+++ b/demo/corsdemo.jl
@@ -1,7 +1,6 @@
 module CorsDemo
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 
 allowed_origins = [ "Access-Control-Allow-Origin" => "*" ]

--- a/demo/crondemo.jl
+++ b/demo/crondemo.jl
@@ -1,7 +1,6 @@
 module CronDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using Dates
 

--- a/demo/cronmanagementdemo.jl
+++ b/demo/cronmanagementdemo.jl
@@ -1,7 +1,6 @@
 module CronManagementDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using Dates
 

--- a/demo/customserializer.jl
+++ b/demo/customserializer.jl
@@ -1,7 +1,6 @@
 module CustomSerializerDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using JSON3
 

--- a/demo/dynamicheadersdemo.jl
+++ b/demo/dynamicheadersdemo.jl
@@ -1,7 +1,6 @@
 module DynamicHeadersDemo
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 
 get("/") do req::HTTP.Request

--- a/demo/errorhandling.jl
+++ b/demo/errorhandling.jl
@@ -1,7 +1,6 @@
 module ErrorHandlingDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 
 @get "/" function(req::HTTP.Request)

--- a/demo/main.jl
+++ b/demo/main.jl
@@ -1,6 +1,5 @@
 module Main 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using JSON3
 using StructTypes
@@ -119,4 +118,3 @@ end
 serve(middleware=[CorsHandler])
 
 end
-

--- a/demo/metricsdemo.jl
+++ b/demo/metricsdemo.jl
@@ -1,7 +1,6 @@
 module CronManagementDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using Dates
 

--- a/demo/middlewaredemo.jl
+++ b/demo/middlewaredemo.jl
@@ -1,7 +1,6 @@
 module MiddlewareDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using JSON3
 

--- a/demo/paralleldemo.jl
+++ b/demo/paralleldemo.jl
@@ -1,7 +1,5 @@
 module ParallelDemo 
-
-    include("../src/Oxygen.jl")
-    using .Oxygen
+    using Oxygen
     using HTTP
     using JSON3
     using StructTypes

--- a/demo/routerdemo.jl
+++ b/demo/routerdemo.jl
@@ -1,7 +1,6 @@
 module RouterDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using JSON3
 

--- a/demo/routingfunctions.jl
+++ b/demo/routingfunctions.jl
@@ -1,7 +1,6 @@
 module FunctionsRoutingDemo
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
 using HTTP
 

--- a/demo/swaggerdemo.jl
+++ b/demo/swaggerdemo.jl
@@ -1,7 +1,6 @@
 module SwaggerDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using SwaggerMarkdown
 using StructTypes

--- a/src/autodoc.jl
+++ b/src/autodoc.jl
@@ -5,9 +5,8 @@ using DataStructures
 using Reexport
 using RelocatableFolders
 
-include("util.jl"); using .Util 
-include("cron.jl"); @reexport using .Cron
-
+using ..Util
+@reexport using ..Cron
 export registerschema, docspath, schemapath, getschema, 
     swaggerhtml, redochtml, getschemapath, configdocs, mergeschema, setschema, 
     router, enabledocs, disabledocs, isdocsenabled, registermountedfolder, 

--- a/src/core.jl
+++ b/src/core.jl
@@ -9,6 +9,7 @@ using Suppressor
 using Reexport
 using RelocatableFolders
 
+include("cron.jl")
 include("util.jl");         @reexport using .Util
 include("streamutil.jl");   @reexport using .StreamUtil
 include("autodoc.jl");      @reexport using .AutoDoc

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -7,7 +7,7 @@ using DataStructures
 using Statistics
 using RelocatableFolders
 
-include("util.jl"); using .Util
+using ..Util
 
 export MetricsMiddleware, get_history, clear_history, push_history, 
     HTTPTransaction,

--- a/test/bodyparsertests.jl
+++ b/test/bodyparsertests.jl
@@ -4,11 +4,8 @@ using Test
 using HTTP
 using StructTypes
 
-include("../src/Oxygen.jl")
-using .Oxygen
-
-include("../src/util.jl")
-using .Util: set_content_size!
+using Oxygen
+using Oxygen.Util: set_content_size!
 
 struct rank
     title   :: String 

--- a/test/crontests.jl
+++ b/test/crontests.jl
@@ -5,12 +5,8 @@ using JSON3
 using StructTypes
 using Sockets
 using Dates 
-
-include("../src/Oxygen.jl")
-using .Oxygen
-
-include("../src/cron.jl")
-using .Cron: iscronmatch, isweekday, lastweekdayofmonth, 
+using Oxygen
+using Oxygen.Cron: iscronmatch, isweekday, lastweekdayofmonth, 
             next, sleep_until, lastweekday, nthweekdayofmonth, 
             matchexpression
 

--- a/test/metricstests.jl
+++ b/test/metricstests.jl
@@ -2,11 +2,9 @@ module MetricsTests
 using Test
 using Dates 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
-include("../src/metrics.jl")
-using .Metrics:
+using Oxygen.Metrics:
     percentile, HTTPTransaction, TimeseriesRecord, get_history, push_history,
     group_transactions, get_transaction_metrics, recent_transactions,
     all_endpoint_metrics, server_metrics, error_distribution,

--- a/test/rendertests.jl
+++ b/test/rendertests.jl
@@ -1,9 +1,7 @@
 module BodyParserTests 
 using Test
 using HTTP
-
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
 @testset "Render Module Tests" begin
 

--- a/test/routingfunctionstests.jl
+++ b/test/routingfunctionstests.jl
@@ -5,9 +5,7 @@ using JSON3
 using StructTypes
 using Sockets
 using Dates 
-
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
 ##### Setup Routes #####
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,9 +5,7 @@ using JSON3
 using StructTypes
 using Sockets
 using Dates 
-
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
 include("metricstests.jl")
 include("templatingtests.jl")

--- a/test/templatingtests.jl
+++ b/test/templatingtests.jl
@@ -4,9 +4,7 @@ using Test
 using HTTP
 using Mustache
 using OteraEngine
-
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
 # ensure the init is called so we can load the extensions
 Oxygen.__init__()


### PR DESCRIPTION
I noticed when developing https://github.com/OxygenFramework/Oxygen.jl/pull/158 the tests showed a lot of messages like
```julia
WARNING: Method definition get(Function, String) in module Core at /Users/eph/Oxygen.jl/src/core.jl:504 overwritten in module Core on the same line (check for duplicate calls to `include`).
WARNING: Method definition get(Function, Function) in module Core at /Users/eph/Oxygen.jl/src/core.jl:505 overwritten in module Core on the same line (check for duplicate calls to `include`).
```

This fixes some of them by loading the module once.

A rule of thumb in Julia is each file should be `include`ed exactly once. Each time you `include` a module, it creates a separate copy of it. Instead, we should use relative `using` statements like `using ..Util`. See [this section](https://docs.julialang.org/en/v1/manual/modules/#Submodules-and-relative-paths) of the Julia manual for more.

I suspect some of this is to facillitate a testing workflow. I wonder if perhaps you aren't using [Revise](https://github.com/timholy/Revise.jl), and thus reinclude the source code to reload it? 

I would highly recommend Revise for this, it is even mentioned in the main Julia manual: https://docs.julialang.org/en/v1/manual/workflow-tips/#Revise-based-workflows.