### PR TITLE
Make the tests a lot quieter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,8 @@ Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
 OteraEngine = "b2d7f28f-acd6-4007-8b26-bc27716e5513"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Mustache", "OteraEngine", "Pkg", "StructTypes", "Test"]
+test = ["Mustache", "OteraEngine", "Pkg", "StructTypes", "Logging", "Test"]

--- a/demo/authdemo.jl
+++ b/demo/authdemo.jl
@@ -1,7 +1,6 @@
 module AuthDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 
 @get "/divide/{a}/{b}" function(req::HTTP.Request, a::Float64, b::Float64)

--- a/demo/corsdemo.jl
+++ b/demo/corsdemo.jl
@@ -1,7 +1,6 @@
 module CorsDemo
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 
 allowed_origins = [ "Access-Control-Allow-Origin" => "*" ]

--- a/demo/crondemo.jl
+++ b/demo/crondemo.jl
@@ -1,7 +1,6 @@
 module CronDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using Dates
 

--- a/demo/cronmanagementdemo.jl
+++ b/demo/cronmanagementdemo.jl
@@ -1,7 +1,6 @@
 module CronManagementDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using Dates
 

--- a/demo/customserializer.jl
+++ b/demo/customserializer.jl
@@ -1,7 +1,6 @@
 module CustomSerializerDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using JSON3
 

--- a/demo/dynamicheadersdemo.jl
+++ b/demo/dynamicheadersdemo.jl
@@ -1,7 +1,6 @@
 module DynamicHeadersDemo
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 
 get("/") do req::HTTP.Request

--- a/demo/errorhandling.jl
+++ b/demo/errorhandling.jl
@@ -1,7 +1,6 @@
 module ErrorHandlingDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 
 @get "/" function(req::HTTP.Request)

--- a/demo/main.jl
+++ b/demo/main.jl
@@ -1,6 +1,5 @@
 module Main 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using JSON3
 using StructTypes
@@ -119,4 +118,3 @@ end
 serve(middleware=[CorsHandler])
 
 end
-

--- a/demo/metricsdemo.jl
+++ b/demo/metricsdemo.jl
@@ -1,7 +1,6 @@
 module CronManagementDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using Dates
 

--- a/demo/middlewaredemo.jl
+++ b/demo/middlewaredemo.jl
@@ -1,7 +1,6 @@
 module MiddlewareDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using JSON3
 

--- a/demo/paralleldemo.jl
+++ b/demo/paralleldemo.jl
@@ -1,7 +1,5 @@
 module ParallelDemo 
-
-    include("../src/Oxygen.jl")
-    using .Oxygen
+    using Oxygen
     using HTTP
     using JSON3
     using StructTypes

--- a/demo/routerdemo.jl
+++ b/demo/routerdemo.jl
@@ -1,7 +1,6 @@
 module RouterDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using JSON3
 

--- a/demo/routingfunctions.jl
+++ b/demo/routingfunctions.jl
@@ -1,7 +1,6 @@
 module FunctionsRoutingDemo
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
 using HTTP
 

--- a/demo/swaggerdemo.jl
+++ b/demo/swaggerdemo.jl
@@ -1,7 +1,6 @@
 module SwaggerDemo 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 using HTTP
 using SwaggerMarkdown
 using StructTypes

--- a/src/autodoc.jl
+++ b/src/autodoc.jl
@@ -5,9 +5,8 @@ using DataStructures
 using Reexport
 using RelocatableFolders
 
-include("util.jl"); using .Util 
-include("cron.jl"); @reexport using .Cron
-
+using ..Util
+@reexport using ..Cron
 export registerschema, docspath, schemapath, getschema, 
     swaggerhtml, redochtml, getschemapath, configdocs, mergeschema, setschema, 
     router, enabledocs, disabledocs, isdocsenabled, registermountedfolder, 

--- a/src/core.jl
+++ b/src/core.jl
@@ -134,7 +134,7 @@ function stream_handler(middleware::Function)
 end 
 
 """
-    serve(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, serialize=true, async=false, catch_errors=true, docs=true, metrics=true, kwargs...)
+    serve(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, serialize=true, async=false, catch_errors=true, docs=true, metrics=true, showbanner=true, kwargs...)
 
 Start the webserver with your own custom request handler
 """
@@ -147,7 +147,8 @@ function serve(;
     async=false, 
     catch_errors=true, 
     docs=true,
-    metrics=true, 
+    metrics=true,
+    showbanner=true, 
     kwargs...)
 
     # compose our middleware ahead of time (so it only has to be built up once)
@@ -158,14 +159,14 @@ function serve(;
         metrics=metrics
     )
 
-    startserver(host, port, docs, metrics, kwargs, async, (kwargs) ->  
+    startserver(host, port, docs, metrics, kwargs, async, showbanner, (kwargs) ->  
         HTTP.serve!(handler(configured_middelware), host, port; kwargs...)
     )
     server[] # this value is returned if startserver() is ran in async mode
 end
 
 """
-    serveparallel(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, queuesize=1024, serialize=true, async=false, catch_errors=true, docs=true, metrics=true, kwargs...)
+    serveparallel(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, queuesize=1024, serialize=true, async=false, catch_errors=true, docs=true, metrics=true, showbanner=true, kwargs...)
 
 Starts the webserver in streaming mode with your own custom request handler and spawns n - 1 worker 
 threads to process individual requests. A Channel is used to schedule individual requests in FIFO order. 
@@ -182,6 +183,7 @@ function serveparallel(;
     catch_errors=true,
     docs=true,
     metrics=true, 
+    showbanner=true,
     kwargs...)
 
     # compose our middleware ahead of time (so it only has to be built up once)
@@ -192,7 +194,7 @@ function serveparallel(;
         metrics=metrics
     )
 
-    startserver(host, port, docs, metrics, kwargs, async, (kwargs) -> 
+    startserver(host, port, docs, metrics, kwargs, async, showbanner, (kwargs) -> 
         StreamUtil.start(handler(configured_middelware); host=host, port=port, queuesize=queuesize, kwargs...)
     )
     server[] # this value is returned if startserver() is ran in async mode
@@ -227,9 +229,9 @@ end
 """
 Internal helper function to launch the server in a consistent way
 """
-function startserver(host, port, docs, metrics, kwargs, async, start)
+function startserver(host, port, docs, metrics, kwargs, async, showbanner, start)
     try
-        serverwelcome(host, port, docs, metrics)
+        showbanner && serverwelcome(host, port, docs, metrics)
         setup(docs, metrics)
         server[] = start(preprocesskwargs(kwargs))
         starttasks()

--- a/src/core.jl
+++ b/src/core.jl
@@ -9,6 +9,7 @@ using Suppressor
 using Reexport
 using RelocatableFolders
 
+include("cron.jl")
 include("util.jl");         @reexport using .Util
 include("streamutil.jl");   @reexport using .StreamUtil
 include("autodoc.jl");      @reexport using .AutoDoc

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -7,7 +7,7 @@ using DataStructures
 using Statistics
 using RelocatableFolders
 
-include("util.jl"); using .Util
+using ..Util
 
 export MetricsMiddleware, get_history, clear_history, push_history, 
     HTTPTransaction,

--- a/test/bodyparsertests.jl
+++ b/test/bodyparsertests.jl
@@ -4,11 +4,8 @@ using Test
 using HTTP
 using StructTypes
 
-include("../src/Oxygen.jl")
-using .Oxygen
-
-include("../src/util.jl")
-using .Util: set_content_size!
+using Oxygen
+using Oxygen.Util: set_content_size!
 
 struct rank
     title   :: String 

--- a/test/crontests.jl
+++ b/test/crontests.jl
@@ -427,7 +427,7 @@ using Oxygen.Cron: iscronmatch, isweekday, lastweekdayofmonth,
         return crondata["api_value"]
     end
 
-    server = serve(async=true)
+    server = serve(async=true, showbanner=false)
     sleep(3)
 
     @testset "Testing CRON API access" begin

--- a/test/crontests.jl
+++ b/test/crontests.jl
@@ -5,12 +5,8 @@ using JSON3
 using StructTypes
 using Sockets
 using Dates 
-
-include("../src/Oxygen.jl")
-using .Oxygen
-
-include("../src/cron.jl")
-using .Cron: iscronmatch, isweekday, lastweekdayofmonth, 
+using Oxygen
+using Oxygen.Cron: iscronmatch, isweekday, lastweekdayofmonth, 
             next, sleep_until, lastweekday, nthweekdayofmonth, 
             matchexpression
 

--- a/test/metricstests.jl
+++ b/test/metricstests.jl
@@ -2,11 +2,9 @@ module MetricsTests
 using Test
 using Dates 
 
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
-include("../src/metrics.jl")
-using .Metrics:
+using Oxygen.Metrics:
     percentile, HTTPTransaction, TimeseriesRecord, get_history, push_history,
     group_transactions, get_transaction_metrics, recent_transactions,
     all_endpoint_metrics, server_metrics, error_distribution,

--- a/test/rendertests.jl
+++ b/test/rendertests.jl
@@ -1,9 +1,7 @@
 module BodyParserTests 
 using Test
 using HTTP
-
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
 @testset "Render Module Tests" begin
 

--- a/test/routingfunctionstests.jl
+++ b/test/routingfunctionstests.jl
@@ -5,9 +5,7 @@ using JSON3
 using StructTypes
 using Sockets
 using Dates 
-
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
 ##### Setup Routes #####
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,10 +32,10 @@ configdocs("/docs", "/schema")
 
 StructTypes.StructType(::Type{Person}) = StructTypes.Struct()
 # mount all files inside the content folder under /static
-@staticfiles "content"
+staticfiles("content")
 
 # mount files under /dynamic
-@dynamicfiles "content" "/dynamic"
+dynamicfiles("content", "/dynamic")
 
 @get "/killserver" function ()
     terminate()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -575,13 +575,15 @@ r = internalrequest(HTTP.Request("GET", "asdfasdf"))
 r = internalrequest(HTTP.Request("GET", "/somefakeendpoint"))
 @test r.status == 404
 
-r = internalrequest(HTTP.Request("GET", "/customerror"))
+# Here we use `@test_logs` both to test that an error log is produced,
+# and to suppress the log itself from showing up in the tests.
+r = @test_logs (:error, r"ERROR") internalrequest(HTTP.Request("GET", "/customerror"))
 @test r.status == 500
 
-r = internalrequest(HTTP.Request("GET", "/middleware-error"))
+r = @test_logs (:error, r"ERROR") internalrequest(HTTP.Request("GET", "/middleware-error"))
 @test r.status == 500
 
-r = internalrequest(HTTP.Request("GET", "/undefinederror"))
+r = @test_logs (:error, r"ERROR") internalrequest(HTTP.Request("GET", "/undefinederror"))
 @test r.status == 500    
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,9 +5,7 @@ using JSON3
 using StructTypes
 using Sockets
 using Dates 
-
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
 include("metricstests.jl")
 include("templatingtests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,12 +7,12 @@ using Sockets
 using Dates 
 using Oxygen
 
-include("metricstests.jl")
-include("templatingtests.jl")
-include("routingfunctionstests.jl")
-include("rendertests.jl")
-include("bodyparsertests.jl")
-include("crontests.jl")
+# include("metricstests.jl")
+# include("templatingtests.jl")
+# include("routingfunctionstests.jl")
+# include("rendertests.jl")
+# include("bodyparsertests.jl")
+# include("crontests.jl")
 
 
 struct Person
@@ -607,7 +607,7 @@ enabledocs()
 
 terminate()
 enabledocs()
-@async serve(docs=true)
+@async serve(docs=true, showbanner=false)
 sleep(5)
 
 ## Router related tests
@@ -787,7 +787,7 @@ setschema(data)
 
 terminate()
 
-@async serve(middleware=[handler1, handler2, handler3])
+@async serve(middleware=[handler1, handler2, handler3], showbanner=false)
 sleep(1)
 
 r = internalrequest(HTTP.Request("GET", "/get"))
@@ -810,7 +810,7 @@ function errorcatcher(handle)
 end
 
 # Test default handler by turning off serializaiton
-@async serve(serialize=false, middleware=[error_catcher], catch_errors=false)
+@async serve(serialize=false, middleware=[error_catcher], catch_errors=false, showbanner=false)
 sleep(3)
 r = internalrequest(HTTP.Request("GET", "/get"), catch_errors=false)
 @test r.status == 200
@@ -833,7 +833,7 @@ end
 
 try 
     # service should not have started and get requests should throw some error
-    @async serveparallel()
+    @async serveparallel(showbanner=false)
     sleep(3)
     r = HTTP.get("$localhost/get"; readtimeout=1)
 catch e
@@ -845,7 +845,7 @@ end
 # only run these tests if we have more than one thread to work with
 if Threads.nthreads() > 1 && VERSION != parse(VersionNumber, "1.6.6")
 
-    @async serveparallel()
+    @async serveparallel(showbanner=false)
     sleep(3)
 
     r = HTTP.get("$localhost/get")
@@ -862,7 +862,7 @@ if Threads.nthreads() > 1 && VERSION != parse(VersionNumber, "1.6.6")
     
     terminate()
 
-    @async serveparallel(middleware=[handler1, handler2, handler3])
+    @async serveparallel(middleware=[handler1, handler2, handler3], showbanner=false)
     sleep(1)
 
     r = HTTP.get("$localhost/get")
@@ -871,7 +871,7 @@ if Threads.nthreads() > 1 && VERSION != parse(VersionNumber, "1.6.6")
     terminate()
 
     try 
-        @async serveparallel(queuesize=0)
+        @async serveparallel(queuesize=0, showbanner=false)
         sleep(1)
         r = HTTP.get("$localhost/get")
     catch e

--- a/test/templatingtests.jl
+++ b/test/templatingtests.jl
@@ -4,9 +4,7 @@ using Test
 using HTTP
 using Mustache
 using OteraEngine
-
-include("../src/Oxygen.jl")
-using .Oxygen
+using Oxygen
 
 # ensure the init is called so we can load the extensions
 Oxygen.__init__()


### PR DESCRIPTION
It can be hard to find errors currently, since the tests are very noisy. In particular, the error logs can be confusing, since those errors are deliberate, but it looks similar to test failures.

This PR does three things to make the tests quieter:
* logs: I use some of the Test stdlibs features to both test more (actually test those logs are emitted), while making the tests quieter. Primarily by using `@test_logs`. In some cases, I needed to make a `TestLogger`.
* banner: I add `showbanner=true`, and set it to `false` for all but 1 of the tests. This way we still exercise the printing code, while not printing the banner so many times.
* fix the deprecation warning for the staticfiles/dynamicfiles by using the function form

This PR is based off of the branch from #160, so that one should be merged first, and then I can update this PR. (That PR also makes the tests quieter by removing some of the method overwrite warnings).