### PR TITLE
making "required" boolean, so it passes validation

### DIFF
--- a/src/autodoc.jl
+++ b/src/autodoc.jl
@@ -261,7 +261,7 @@ function registerschema(docs::Documenation, path::String, httpmethod::String, pa
         param = Dict( 
             "in" => "path",
             "name" => "$name", 
-            "required" => "true",
+            "required" => true,
             "schema" => Dict(
                 "type" => gettype(type)
             )

--- a/test/originaltests.jl
+++ b/test/originaltests.jl
@@ -754,7 +754,7 @@ mergeschema(Dict(
                     Dict(
                         "name" => "a",
                         "in" => "path",
-                        "required" => "true",
+                        "required" => true,
                         "schema" => Dict(
                             "type" => "number"
                         )
@@ -762,7 +762,7 @@ mergeschema(Dict(
                     Dict(
                         "name" => "b",
                         "in" => "path",
-                        "required" => "true",
+                        "required" => true,
                         "schema" => Dict(
                             "type" => "number"
                         )


### PR DESCRIPTION
This way the schema can be used as-is in an external API Client app (e.g. Bruno, Insomnia, ...). Of course, the alternative is you add a Dict with `"required" => true` and `mergeschema`. But I think it's better if it is valid right off the bat. By "valid" I mean, passes validation from e.g. https://validator.swagger.io/ 