### PR TITLE
feature/interactive-threadpool-warning

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -10,7 +10,7 @@ using Dates
 using Reexport
 using RelocatableFolders
 using DataStructures: CircularDeque
-import Base.Threads: lock
+import Base.Threads: lock, nthreads
 
 include("util.jl");         @reexport using .Util
 include("types.jl");        @reexport using .Types 
@@ -51,6 +51,16 @@ function serverwelcome(host::String, port::Int, docs::Bool, metrics::Bool, paral
     end
     if parallel
         @info "🚀 Running in parallel mode with $(Threads.nthreads()) threads"
+        # Check if the current julia version supports interactive threadpools
+        if hasmethod(getfield(Threads, Symbol("@spawn")), Tuple{LineNumberNode, Module, Symbol, Expr})
+            # Add a warnign if the interactive threadpool is empty when running in parallel mode
+            if nthreads(:interactive) == 0
+                @warn """
+                🚨 Interactive threadpool is empty. This can hurt performance when running in parallel mode.
+                Try launching julia like \"julia --threads 3,1\" to add 1 thread to the interactive threadpool.
+                """
+            end
+        end
     end
 end
 


### PR DESCRIPTION
Added warning log that checks for empty interactive threadpools when running in parallel mode

Interactive threadpools are designed for handling many short-lived tasks, which could otherwise overwhelm the scheduler in the default threadpool. If your version of julia supports this feature, then it will only help performance to designate at least one thread to handling these small tasks. 