### PR TITLE
Add revise argument to serve(...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,40 @@ end
 
 When the server is ran, all tasks are started automatically. But the module also provides utilities to have more fine-grained control over the running tasks using the following functions: `starttasks()`, `stoptasks()`, and `cleartasks()`
 
+## Hot reloads with Revise
+
+Oxygen can interoperates with Revise to provide hot reloads, speeding up development. Since Revise recommends keeping all code to be revised in a package, you first need to move to this type of a layout.
+
+[First make sure your `Project.toml` has the required fields such as `name` to work on a package rather than a project.](https://pkgdocs.julialang.org/v1/toml-files/)
+
+Next, write the main code for you routes in a module `src/MyModule.jl`:
+
+```
+module MyModule
+
+using Oxygen; @oxidise
+
+@get "/greet" function(req::HTTP.Request)
+    return "hello world!"
+end
+
+end
+```
+
+Then you can make a `debug.jl` entrypoint script:
+
+```
+using Revise
+using Oxygen
+using MyModule
+
+MyModule.serve(revise=:eager)
+```
+
+The `revise` option can also be set to `:prerequest`, in which case revisions will always be left to just before a request is served, rather than being attempted eagerly when source files change on disk.
+
+Note that you should run another entrypoint script without Revise in production.
+
 ## Multiple Instances
 
 In some advanced scenarios, you might need to spin up multiple web severs within the same module on different ports. Oxygen provides both a static and dynamic way to create multiple instances of a web server.

--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ using MyModule
 MyModule.serve(revise=:eager)
 ```
 
-The `revise` option can also be set to `:prerequest`, in which case revisions will always be left to just before a request is served, rather than being attempted eagerly when source files change on disk.
+The `revise` option can also be set to `:lazy`, in which case revisions will always be left to just before a request is served, rather than being attempted eagerly when source files change on disk.
 
 Note that you should run another entrypoint script without Revise in production.
 

--- a/demo/ProjectBasedDemo/Project.toml
+++ b/demo/ProjectBasedDemo/Project.toml
@@ -1,0 +1,10 @@
+name = "ProjectBasedDemo"
+uuid = "1a566602-ad7c-42d2-967d-2280445e9c07"
+authors = ["Frankie Robertson <frankie@robertson.name>"]
+version = "0.1.0"
+
+[deps]
+Oxygen = "df9a0d86-3283-4920-82dc-4555fc0d1d8b"
+
+[compat]
+Oxygen = "1.5.13"

--- a/demo/ProjectBasedDemo/eager.jl
+++ b/demo/ProjectBasedDemo/eager.jl
@@ -1,0 +1,4 @@
+using Revise
+using ProjectBasedDemo
+
+ProjectBasedDemo.serve(revise=:eager)

--- a/demo/ProjectBasedDemo/norevise.jl
+++ b/demo/ProjectBasedDemo/norevise.jl
@@ -1,0 +1,3 @@
+using ProjectBasedDemo
+
+ProjectBasedDemo.serve()

--- a/demo/ProjectBasedDemo/prerequest.jl
+++ b/demo/ProjectBasedDemo/prerequest.jl
@@ -1,0 +1,4 @@
+using Revise
+using ProjectBasedDemo
+
+ProjectBasedDemo.serve(revise=:prerequest)

--- a/demo/ProjectBasedDemo/prerequest.jl
+++ b/demo/ProjectBasedDemo/prerequest.jl
@@ -1,4 +1,0 @@
-using Revise
-using ProjectBasedDemo
-
-ProjectBasedDemo.serve(revise=:prerequest)

--- a/demo/ProjectBasedDemo/src/ProjectBasedDemo.jl
+++ b/demo/ProjectBasedDemo/src/ProjectBasedDemo.jl
@@ -1,0 +1,24 @@
+module ProjectBasedDemo
+
+using Oxygen; @oxidise
+
+@get("/") do req
+    "home" 
+end
+
+@get("/nihao") do req
+    "你好"
+end
+
+@get "/greet" function()
+    "hello world!"
+end
+
+@get "/saluer" () -> begin
+    "Bonjour le monde!"
+end
+
+@get "/saludar" () -> "¡Hola Mundo!"
+@get "/salutare" f() = "ciao mondo!"
+
+end

--- a/src/Oxygen.jl
+++ b/src/Oxygen.jl
@@ -1,5 +1,14 @@
 module Oxygen
 
+const WAS_LOADED_AFTER_REVISE = Ref(false)
+
+function __init__()
+    if isdefined(Main, :Revise)
+        WAS_LOADED_AFTER_REVISE[] = true
+    end
+    do_requires()
+end
+
 include("core.jl"); using .Core
 include("instances.jl"); using .Instances
 include("extensions/load.jl");
@@ -20,8 +29,8 @@ macro oxidise()
         import Oxygen
         import Oxygen: PACKAGE_DIR, Context, Nullable
         import Oxygen: GET, POST, PUT, DELETE, PATCH, STREAM, WEBSOCKET
-        
-        const CONTEXT = Ref{Context}(Context())
+
+        const CONTEXT = Ref{Context}(Context(; mod=$(__module__)))
         include(joinpath(PACKAGE_DIR, "methods.jl"))
         
         nothing; # to hide last definition

--- a/src/context.jl
+++ b/src/context.jl
@@ -42,7 +42,6 @@ end
 
 @kwdef struct EagerReviseService
     task::Task
-    lock::ReentrantLock
     done::Ref{Bool}
 end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -113,7 +113,7 @@ function serve(ctx::Context;
     docs_path   = "/docs",
     schema_path = "/schema",
     external_url = nothing,
-    revise      = :none, # :none, :prerequest, :eager
+    revise      = :none, # :none, :lazy, :eager
     kwargs...) :: Server
 
     # set the external url if it's passed
@@ -132,7 +132,7 @@ function serve(ctx::Context;
     ctx.docs.router[] = Router()
 
     # setup revise if requested
-    if revise == :prerequest || revise == :eager
+    if revise == :lazy || revise == :eager
         if !WAS_LOADED_AFTER_REVISE[]
             error("You must load Revise.jl before Oxygen.jl to use the `revise` option")
         end

--- a/src/core.jl
+++ b/src/core.jl
@@ -123,6 +123,9 @@ function serve(ctx::Context;
 
     # setup revise if requested
     if revise == :lazy || revise == :eager
+        if parallel
+            @warn "You are attempting to use Revise with multiple threads. Please note that Revise 3.5.18 and earlier are not threadsafe."
+        end
         if !WAS_LOADED_AFTER_REVISE[]
             error("You must load Revise.jl before Oxygen.jl to use the `revise` option")
         end

--- a/src/core.jl
+++ b/src/core.jl
@@ -11,6 +11,7 @@ using Reexport
 using RelocatableFolders
 using DataStructures: CircularDeque
 import Base.Threads: lock, nthreads
+import ..WAS_LOADED_AFTER_REVISE
 
 include("errors.jl");       @reexport using .Errors
 include("util.jl");         @reexport using .Util
@@ -65,9 +66,34 @@ function serverwelcome(external_url::String, docs::Bool, metrics::Bool, parallel
     end
 end
 
+struct ReviseHandler
+    ctx::Context
+end
+
+function (handler::ReviseHandler)(handle)
+    req -> begin
+        Revise = Main.Revise
+        eager_revise = handler.ctx.service.eager_revise[]
+        if eager_revise !== nothing
+            lock(eager_revise.lock)
+        end
+        try
+            if !isempty(Revise.revision_queue)
+                @info "🗘  Starting pre-request revision"
+                Revise.revise()
+                @info "👍 Pre-request revision finished"
+            end
+        finally
+            if eager_revise !== nothing
+                unlock(eager_revise.lock)
+            end
+        end
+        invokelatest(handle, req)
+    end
+end
 
 """
-    serve(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, async=false, parallel=false, serialize=true, catch_errors=true, docs=true, metrics=true, show_errors=true, show_banner=true, docs_path="/docs", schema_path="/schema", external_url=nothing, kwargs...)
+    serve(; middleware::Vector=[], handler=stream_handler, host="127.0.0.1", port=8080, async=false, parallel=false, serialize=true, catch_errors=true, docs=true, metrics=true, show_errors=true, show_banner=true, docs_path="/docs", schema_path="/schema", external_url=nothing, revise, kwargs...)
 
 Start the webserver with your own custom request handler
 """
@@ -87,6 +113,7 @@ function serve(ctx::Context;
     docs_path   = "/docs",
     schema_path = "/schema",
     external_url = nothing,
+    revise      = :none, # :none, :prerequest, :eager
     kwargs...) :: Server
 
     # set the external url if it's passed
@@ -103,6 +130,17 @@ function serve(ctx::Context;
 
     # intitialize documenation router (used by docs and metrics)
     ctx.docs.router[] = Router()
+
+    # setup revise if requested
+    if revise == :prerequest || revise == :eager
+        if !WAS_LOADED_AFTER_REVISE[]
+            error("You must load Revise.jl before Oxygen.jl to use the `revise` option")
+        end
+        if ctx.mod === nothing
+            @warn "You are trying to use the `revise` option without @oxidise. Code in the `Main` module, which likely includes your routes, will not be tracked and revised."
+        end
+        insert!(middleware, 1, ReviseHandler(ctx))
+    end
 
     # compose our middleware ahead of time (so it only has to be built up once)
     configured_middelware = setupmiddleware(ctx; middleware, serialize, catch_errors, docs, metrics, show_errors)
@@ -124,9 +162,45 @@ function serve(ctx::Context;
         handle_stream = parallel_stream_handler(handle_stream)
     end
 
+    if revise == :eager
+        ctx.service.eager_revise[] = start_revise_service()
+    end
+
     # The cleanup of resources are put at the topmost level in `methods.jl`
-    return startserver(ctx; host, port, show_banner, docs, metrics, parallel, async, kwargs, start=(kwargs) ->
-        HTTP.serve!(handle_stream, host, port; kwargs...))
+    try
+        return startserver(ctx; host, port, show_banner, docs, metrics, parallel, async, kwargs, start=(kwargs) ->
+            HTTP.serve!(handle_stream, host, port; kwargs...))
+    finally
+        if ctx.service.eager_revise[] !== nothing && async == false
+            close(ctx.service.eager_revise[])
+        end
+    end
+end
+
+function start_revise_service()
+    revise_lock = ReentrantLock()
+    revise_task_done = Ref(false)
+    revise_task = @async begin
+        Revise = Main.Revise
+        while true
+            if revise_task_done[]
+                break
+            end
+            wait(Revise.revision_event)
+            if revise_task_done[]
+                break
+            end
+            lock(revise_lock)
+            @info "🗘  Starting eager revision"
+            try
+                Revise.revise()
+            finally
+                unlock(revise_lock)
+            end
+            @info "👍 Eager revision finished"
+        end
+    end
+    EagerReviseService(revise_task, revise_lock, revise_task_done)
 end
 
 

--- a/src/extensions/load.jl
+++ b/src/extensions/load.jl
@@ -23,7 +23,7 @@ function response(content::String, status=200, headers=[]; detect=true) :: HTTP.
     return response
 end
 
-function __init__()
+function do_requires()
 
 
     ################################################################


### PR DESCRIPTION
Fixes https://github.com/OxygenFramework/Oxygen.jl/issues/122

@JanisErdmanis This implementation is guided quite a bit by your ideas:

 * We guide the user towards loading Revise themselves
 * We warn the user in case they're code seems to not be running in a package. We let them continue anyway, since it should be possible to use includet, or its possible to only want updates from some other package you are developing.
 * Users can run without eager revisions if they want
 * There are locks around revise to prevent simultaneous eager and pre-request revisions

There's some differences too:

 * Revise is not enabled implicitly after loading, but a keyword option is required. I think this is less surprising. Some people load Revise in their startup files. Also it seems to me like having Revise in production could exacerbate security issues since now any change an attacked can write to code files are loaded immediately.

@ndortega I haven't added Revise as a dependency, since I think if Oxygen imports Revise it is could be too late. As a side benefit, people can keep their production Oxygen project completely Revise-free, which as said seems like it could be a useful defense-in-depth precaution.