### PR TITLE
prioritized route proof of concept

### DIFF
--- a/serve-test/Project.toml
+++ b/serve-test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
+Oxygen = "df9a0d86-3283-4920-82dc-4555fc0d1d8b"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/serve-test/Project.toml
+++ b/serve-test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
 Oxygen = "df9a0d86-3283-4920-82dc-4555fc0d1d8b"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/serve-test/blocked-serve.jl
+++ b/serve-test/blocked-serve.jl
@@ -2,6 +2,7 @@ using Base.Threads
 using Infiltrator
 using Revise
 using Oxygen
+using HTTP
 ENV["JULIA_DEBUG"] = "Oxygen"
 
 # Run this with -t 1,1
@@ -37,7 +38,9 @@ end
 end
 
 function start()
-    serveparallel()
+    serveparallel(
+        is_prioritized = (req::HTTP.Request) -> req.target == "/health"
+    )
 end
 
 start()

--- a/serve-test/blocked-serve.jl
+++ b/serve-test/blocked-serve.jl
@@ -1,0 +1,43 @@
+using Base.Threads
+using Infiltrator
+using Revise
+using Oxygen
+ENV["JULIA_DEBUG"] = "Oxygen"
+
+# Run this with -t 1,1
+
+println("$(nthreadpools()) threadpools. default=$(nthreads(:default)) interactive=$(nthreads(:interactive))")
+
+function block(n::Int)
+    start_time = time()
+    while (time() - start_time) < n
+    end
+    return "Blocking complete after $n seconds"
+end
+
+
+@get "/health" function()
+    @info "entered /health threadid=$(Threads.threadid())"
+    json(Dict(:status => "healthy"))
+end
+
+@get "/block" function ()
+    block_time = 10
+    @info "blocking for $block_time seconds. threadid=$(Threads.threadid())"
+    # using block because sleep() would yield
+    block(block_time)
+    @info "done blocking threadid=$(Threads.threadid())"
+    text("done")
+end
+
+@get "/throw" function()
+    throw(
+        ErrorException("error from route impl")
+    )
+end
+
+function start()
+    serveparallel()
+end
+
+start()


### PR DESCRIPTION
Proof of concept and proposal for prioritized requests.
Feature request issue https://github.com/OxygenFramework/Oxygen.jl/issues/223

This approach examines `HTTP.Request` before spawning a thread in the `:default` threadpool. If condition is true, it handles the request in the Main thread, which is a reserved thread in the `:interactive` pool if you launched server with `-t auto,1`

## Proposed API

new kwarg on `serve()`
`is_prioritized: (req::HTTP.Request) -> bool`
Affects `parallel` mode; if the function returns true, the request will be handled in the current main thread instead of spawning a thread from the `:default` threadpool. This allows the server to handle requests when all `:default` threads are busy. The main use case is to allow health checks to respond when all worker threads are busy. For this to work, you should launch Julia with at least one dedicated interactive thread. e.g. `--threads=auto,1`, see [Julia multi-threading documentation](https://docs.julialang.org/en/v1/manual/multi-threading/).

```julia
    serveparallel(
        is_prioritized = (req::HTTP.Request) -> req.target == "/health"
    )
```

## TODO

- [ ] acceptance of implementation and config
- [ ] cleanup PR
- [ ] documentation
- [ ] test
