### PR TITLE
Fix #231

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -132,6 +132,7 @@ function serve(ctx::Context;
         if ctx.mod === nothing
             @warn "You are trying to use the `revise` option without @oxidise. Code in the `Main` module, which likely includes your routes, will not be tracked and revised."
         end
+        middleware = convert(Vector{Any}, middleware)
         insert!(middleware, 1, ReviseHandler(ctx))
     end
 


### PR DESCRIPTION
Fixes #231 

This fixes the problem which is that a error when Revise is used together with a middleware vector which isn't Any[] (note that a single element array will always be typed).

I've also added some tests which ended up being a bit simpler than I thought.