### PR TITLE
bugfix/docs-use-relative-schema-path

### DIFF
--- a/src/autodoc.jl
+++ b/src/autodoc.jl
@@ -442,7 +442,7 @@ function swaggerhtml(schemapath::String, docspath::String) :: HTTP.Response
             <script>
                 window.onload = () => {
                     window.ui = SwaggerUIBundle({
-                        url: window.location.origin + "$schemapath",
+                        url: "$schemapath",
                         dom_id: '#swagger-ui',
                     });
                 };


### PR DESCRIPTION
removed the hardcoded "window.location.origin" and now use the relative path for loading the swagger docs