### PR TITLE
bump WGLMakie version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ WGLMakieExt = ["WGLMakie", "Bonito"]
 
 [compat]
 Bonito = "^4"
-CairoMakie = "^0.11"
+CairoMakie = "^0.13"
 DataStructures = "^0.18.15"
 Dates = "^1"
 HTTP = "^1.8"

--- a/Project.toml
+++ b/Project.toml
@@ -50,7 +50,7 @@ Sockets = "^1"
 Statistics = "^1"
 StructTypes = "^1"
 Suppressor = "^0.2.6"
-WGLMakie = "^0.9"
+WGLMakie = "^0.11"
 julia = "^1.10"
 
 [extras]


### PR DESCRIPTION
There're some precompilation issues when trying to use latest Oxygen.jl with older version of WGLMakie.jl
This PR bumps WGLMakie version for WGLMakieExt