### PR TITLE
use relpath utility to compute mountpath

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Oxygen"
 uuid = "df9a0d86-3283-4920-82dc-4555fc0d1d8b"
 authors = ["Nathan Ortega <nate.ortega95@gmail.com>"]
 repo = "https://github.com/OxygenFramework/Oxygen.jl.git"
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/utilities/fileutil.jl
+++ b/src/utilities/fileutil.jl
@@ -63,7 +63,7 @@ function mountfolder(folder::String, mountdir::String, addroute)
     iteratefiles(folder) do filepath
 
         # remove the first occurrence of the root folder from the filepath before "mounting"
-        cleanedmountpath = replace(filepath, "$(folder)$(separator)" => "", count=1)
+        cleanedmountpath = relpath(filepath, folder)
 
         # make sure to replace any system path separator with "/"
         cleanedmountpath = replace(cleanedmountpath, separator => "/")

--- a/test/originaltests.jl
+++ b/test/originaltests.jl
@@ -33,6 +33,9 @@ staticfiles("content")
 #@dynamicfiles "content" "/dynamic"
 dynamicfiles("content", "/dynamic")
 
+# test that trailing system file path separators are allowed
+dynamicfiles("content/", "/dynamic2")
+
 @get "/killserver" function (; context)
     terminate()
 end
@@ -555,6 +558,10 @@ r = internalrequest(HTTP.Request("GET", "/file"))
 @test text(r) == file("content/sample.html") |> text
 
 r = internalrequest(HTTP.Request("GET", "/dynamic/sample.html"))
+@test r.status == 200
+@test text(r) == file("content/sample.html") |> text
+
+r = internalrequest(HTTP.Request("GET", "/dynamic2/sample.html"))
 @test r.status == 200
 @test text(r) == file("content/sample.html") |> text
 


### PR DESCRIPTION
Hello! First of all, thanks for this lovely library, I'm finding it extremely handy.

I've noticed that passing a filesystem path that ends with a separator causes `dynamicfiles` and `staticfiles` to fail. This is a bit problematic because often I get the path from julia, which adds the trailing separator to folders when normalizing paths.

The fix is relatively easy, it's sufficient to use the builtin utility `relpath` to compute the relative path rather than manually manipulating strings.

It'd be great to get a patch release after this is merged if possible, so I've bumped the patch version number.