### PR TITLE
Fix: OpenAPI required fields should be array of property names (OpenAPI 3.0)

### DIFF
--- a/test/autodoctests.jl
+++ b/test/autodoctests.jl
@@ -4,6 +4,7 @@ using Test
 using Dates
 using Oxygen; @oxidise
 using ..Constants
+using ..TestUtils
 
 struct Car
     name::String
@@ -58,13 +59,13 @@ schemas = ctx.docs.schema["components"]["schemas"]
     # ensure the generated Car schema aligns
     car = schemas["Car"]
     @test car["type"] == "object"
-    @test haskey(car, "required") && all( x -> x in car["required"], ["name"])
+    @test_has_key_and_values car "required" ["name"]
     @test car["properties"]["name"]["type"] == "string"
 
     # ensure the generated Person schema aligns
     person = schemas["Person"]
     @test person["type"] == "object"
-    @test haskey(person, "required") && all( x -> x in person["required"], ["name", "car"])
+    @test_has_key_and_values person "required" ["name", "car"]
     @test person["properties"]["name"]["type"] == "string"
     @test person["properties"]["car"]["\$ref"] == "#/components/schemas/Car"
 
@@ -81,14 +82,14 @@ schemas = ctx.docs.schema["components"]["schemas"]
     party_invite = schemas["PartyInvite"]
     # Properties without default vaules should be required
     @test party_invite["type"] == "object"
-    @test haskey(party_invite, "required") && all( x -> x in party_invite["required"], ["party", "time"])
+    @test_has_key_and_values party_invite "required" ["party", "time"]
     @test party_invite["properties"]["time"]["type"] == "string"
     @test party_invite["properties"]["time"]["format"] == "date-time"
 
     # ensure the generated PartyInvite schema aligns
     event_invite = schemas["EventInvite"]
     @test event_invite["type"] == "object"
-    @test haskey(event_invite, "required") && all( x -> x in event_invite["required"], ["party", "times"])
+    @test_has_key_and_values event_invite "required" ["party", "times"]
     @test event_invite["properties"]["times"]["type"] == "array"
     @test event_invite["properties"]["times"]["items"]["format"] == "date-time"
     @test event_invite["properties"]["times"]["items"]["type"] == "string"

--- a/test/autodoctests.jl
+++ b/test/autodoctests.jl
@@ -58,35 +58,37 @@ schemas = ctx.docs.schema["components"]["schemas"]
     # ensure the generated Car schema aligns
     car = schemas["Car"]
     @test car["type"] == "object"
-    @test car["properties"]["name"]["required"] == true
+    @test haskey(car, "required") && all( x -> x in car["required"], ["name"])
     @test car["properties"]["name"]["type"] == "string"
 
     # ensure the generated Person schema aligns
     person = schemas["Person"]
     @test person["type"] == "object"
-    @test person["properties"]["name"]["required"] == true
+    @test haskey(person, "required") && all( x -> x in person["required"], ["name", "car"])
     @test person["properties"]["name"]["type"] == "string"
     @test person["properties"]["car"]["\$ref"] == "#/components/schemas/Car"
 
     # ensure the generated Party schema aligns
     party = schemas["Party"]
+    # There should be no required key defined if no fields are required
+    @test !haskey(party, "required")
     @test party["type"] == "object"
-    @test party["properties"]["guests"]["required"] == false
     @test party["properties"]["guests"]["type"] == "array"
     @test party["properties"]["guests"]["items"]["\$ref"] == "#/components/schemas/Person"
     @test party["properties"]["guests"]["default"] == "[{\"name\":\"Alice\",\"car\":{\"name\":\"Toyota\"}},{\"name\":\"Bob\",\"car\":{\"name\":\"Honda\"}}]"
     
     # ensure the generated PartyInvite schema aligns
     party_invite = schemas["PartyInvite"]
+    # Properties without default vaules should be required
     @test party_invite["type"] == "object"
-    @test party_invite["properties"]["time"]["required"] == true
+    @test haskey(party_invite, "required") && all( x -> x in party_invite["required"], ["party", "time"])
     @test party_invite["properties"]["time"]["type"] == "string"
     @test party_invite["properties"]["time"]["format"] == "date-time"
 
     # ensure the generated PartyInvite schema aligns
     event_invite = schemas["EventInvite"]
     @test event_invite["type"] == "object"
-    @test event_invite["properties"]["times"]["required"] == true
+    @test haskey(event_invite, "required") && all( x -> x in event_invite["required"], ["party", "times"])
     @test event_invite["properties"]["times"]["type"] == "array"
     @test event_invite["properties"]["times"]["items"]["format"] == "date-time"
     @test event_invite["properties"]["times"]["items"]["type"] == "string"

--- a/test/extensions/timezonetests.jl
+++ b/test/extensions/timezonetests.jl
@@ -7,6 +7,7 @@ using Dates
 using TimeZones
 using Oxygen; @oxidise
 using ..Constants
+using ..TestUtils
 
 # This is the default format given from JS when creating a new date and calling toISOString()
 @testset "UTC ISO 8601 String Parsing Test" begin
@@ -58,7 +59,7 @@ paths = ctx.docs.schema["paths"]
     # ensure the generated Car schema aligns
     time_payload = components["TimePayload"]
     @test time_payload["type"] == "object"
-    @test haskey(time_payload, "required") && all( x -> x in time_payload["required"], ["time"])
+    @test_has_key_and_values time_payload "required" ["time"]
     @test time_payload["properties"]["time"]["type"] == "string"
     @test time_payload["properties"]["time"]["format"] == "date-time"
 end

--- a/test/extensions/timezonetests.jl
+++ b/test/extensions/timezonetests.jl
@@ -58,7 +58,7 @@ paths = ctx.docs.schema["paths"]
     # ensure the generated Car schema aligns
     time_payload = components["TimePayload"]
     @test time_payload["type"] == "object"
-    @test time_payload["properties"]["time"]["required"] == true
+    @test haskey(time_payload, "required") && all( x -> x in time_payload["required"], ["time"])
     @test time_payload["properties"]["time"]["type"] == "string"
     @test time_payload["properties"]["time"]["format"] == "date-time"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 module RunTests 
 
 include("constants.jl"); using .Constants
+include("test_utils.jl"); using .TestUtils
 
 #### Extension Tests ####
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -11,13 +11,10 @@ of that field is a collection which contains all of the passed values.
 It may contain more additional values.
 """
 macro test_has_key_and_values(dict, key, values)
-    quote
-        local keyVal = $(esc(key))
-        local dictVal = $(esc(dict))
-        local testValues = $(esc(values))
-        @test haskey(dictVal, keyVal)
-        @test all( x -> x in dictVal[keyVal], testValues)
-    end
+    esc(quote
+        @test haskey($dict, $key)
+        @test all( x -> x in $dict[$key], $values)
+    end)
 end
 
 end # module

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,23 @@
+module TestUtils
+using Test
+
+export @test_has_key_and_values
+
+"""
+    test_has_key_and_values(dict, key, values)
+
+Asserts that the passed dictionary both safely contains the specified key, and the value
+of that field is a collection which contains all of the passed values. 
+It may contain more additional values.
+"""
+macro test_has_key_and_values(dict, key, values)
+    quote
+        local keyVal = $(esc(key))
+        local dictVal = $(esc(dict))
+        local testValues = $(esc(values))
+        @test haskey(dictVal, keyVal)
+        @test all( x -> x in dictVal[keyVal], testValues)
+    end
+end
+
+end # module


### PR DESCRIPTION
First, my apologies for all that is erroneous, non-standard and so on, please leave comments and I will fix (first PR).

**Issue** This fixes a problem in which OpenAPI object schema definitions are not compatible with OpenAPI 3.0.

Specifically the `required` field should not be a boolean value on each property (this was accepted in OpenAPI 2.0), rather it should be a collection of property names on the parent object.  This fails [validation here](https://editor.swagger.io/). (In my specific application it prevented NSWAG from generating C# stub code).

This PR:
* Fixes the issue in `convertobject()`
* Adds tests to verify a) required collection added for fields without defaults b) required collection omitted when empty.