### PR TITLE
Sequential object references not serialized in OpenAPI generation. Adds nullable field support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,11 +402,15 @@ end
 ```
 
 #### Nullable Types
-You can indicate that a field may be null by declaring it as a Union type with either `Nothing` or `Missing`.
+You can indicate that a field may be null by declaring it as a Union type with `Nothing`.
+> **Note:** While the serializer can handle type `::Union{T,Missing}` it will fail if a default value of `missing` provided. Instead use `::Union{T,Nothing} = nothing`.
+
 ```julia
 @kwdef struct Pet
-    name::Union{String,Nothing}
-    color::Union{ColorStruct,Missing} 
+    name::Union{String,Nothing} # Valid
+    surname::Union{String,Nothing} = nothing # Valid
+    eyecolor::Union{ColorStruct, Missing} # Valid 
+    coatcolor::Union{ColorStruct,Missing} = missing # Invalid: no schema will be generated for `Pet` 
     age::Int = 10
 end
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,17 @@ end
 end
 ```
 
+#### Nullable Types
+You can indicate that a field may be null by declaring it as a Union type with either `Nothing` or `Missing`.
+```julia
+@kwdef struct Pet
+    name::Union{String,Nothing}
+    color::Union{ColorStruct,Missing} 
+    age::Int = 10
+end
+
+```
+
 #### Validation
 
 On top of serializing incoming data, you can also define your own validation rules by using the `validate` function. In the example below we show how to use both `global` and `local` validators in your code.

--- a/src/autodoc.jl
+++ b/src/autodoc.jl
@@ -382,8 +382,9 @@ function convertobject!(type::Type, schemas::Dict) :: Dict
                 current_field["nullable"] = true
             end
             non_null_types = filter(x -> x != Nothing && x != Missing, sub_types)
+            # We only support exactly one concrete (non-missing) type
             if length(non_null_types) != 1 
-                @warn "OpenAPI generation failed $typename.$field_name. Nullable union must have exactly one non-nulled type."
+                @warn "OpenAPI $typename.$field_name: Nullable union must have exactly one non-nulled type."
                 continue
             end
             # Re-assign the current type to be in the non-missing type

--- a/src/utilities/misc.jl
+++ b/src/utilities/misc.jl
@@ -80,8 +80,9 @@ function recursive_merge(x::AbstractVector...)
     
     if !isempty(parameters)
         return [ elements[name] for name in parameters ]
+    # Fix: De-duplicate the flattened vectors (else entries may be cloned)
     else
-        return flattened
+        return unique(flattened)
     end
 end 
 

--- a/src/utilities/misc.jl
+++ b/src/utilities/misc.jl
@@ -80,9 +80,11 @@ function recursive_merge(x::AbstractVector...)
     
     if !isempty(parameters)
         return [ elements[name] for name in parameters ]
-    # Fix: De-duplicate the flattened vectors (else entries may be cloned)
+    # Fix: When returning a vector of primitive values simply prefer 
+    # the final entry over the earlier (instead of combining) which makes 
+    # no sense for items like `required`
     else
-        return unique(flattened)
+        return x[end]
     end
 end 
 

--- a/test/autodoctests.jl
+++ b/test/autodoctests.jl
@@ -4,6 +4,7 @@ using Test
 using Dates
 using Oxygen; @oxidise
 using ..Constants
+using ..TestUtils
 
 struct Car
     name::String
@@ -58,13 +59,13 @@ schemas = ctx.docs.schema["components"]["schemas"]
     # ensure the generated Car schema aligns
     car = schemas["Car"]
     @test car["type"] == "object"
-    @test haskey(car, "required") && all( x -> x in car["required"], ["name"])
+    @test_has_key_and_values car "required" ["name"]
     @test car["properties"]["name"]["type"] == "string"
 
     # ensure the generated Person schema aligns
     person = schemas["Person"]
     @test person["type"] == "object"
-    @test haskey(person, "required") && all( x -> x in person["required"], ["name", "car"])
+    @test_has_key_and_values person "required" ["name", "car"]
     @test person["properties"]["name"]["type"] == "string"
     @test person["properties"]["car"]["\$ref"] == "#/components/schemas/Car"
 
@@ -81,14 +82,14 @@ schemas = ctx.docs.schema["components"]["schemas"]
     party_invite = schemas["PartyInvite"]
     # Properties without default vaules should be required
     @test party_invite["type"] == "object"
-    @test haskey(party_invite, "required") && all( x -> x in party_invite["required"], ["party", "time"])
+    @test_has_key_and_values party_invite "required" ["party", "time"]
     @test party_invite["properties"]["time"]["type"] == "string"
     @test party_invite["properties"]["time"]["format"] == "date-time"
 
     # ensure the generated PartyInvite schema aligns
     event_invite = schemas["EventInvite"]
     @test event_invite["type"] == "object"
-    @test haskey(event_invite, "required") && all( x -> x in event_invite["required"], ["party", "times"])
+    @test_has_key_and_values event_invite "required" ["party", "times"]
     @test event_invite["properties"]["times"]["type"] == "array"
     @test event_invite["properties"]["times"]["items"]["format"] == "date-time"
     @test event_invite["properties"]["times"]["items"]["type"] == "string"

--- a/test/autodoctests.jl
+++ b/test/autodoctests.jl
@@ -59,13 +59,13 @@ schemas = ctx.docs.schema["components"]["schemas"]
     # ensure the generated Car schema aligns
     car = schemas["Car"]
     @test car["type"] == "object"
-    @test_has_key_and_values car "required" ["name"]
+    @test values_present(car, "required", ["name"])
     @test car["properties"]["name"]["type"] == "string"
 
     # ensure the generated Person schema aligns
     person = schemas["Person"]
     @test person["type"] == "object"
-    @test_has_key_and_values person "required" ["name", "car"]
+    @test values_present(person, "required", ["name", "car"])
     @test person["properties"]["name"]["type"] == "string"
     @test person["properties"]["car"]["\$ref"] == "#/components/schemas/Car"
 
@@ -82,14 +82,14 @@ schemas = ctx.docs.schema["components"]["schemas"]
     party_invite = schemas["PartyInvite"]
     # Properties without default vaules should be required
     @test party_invite["type"] == "object"
-    @test_has_key_and_values party_invite "required" ["party", "time"]
+    @test values_present(party_invite, "required", ["party", "time"])
     @test party_invite["properties"]["time"]["type"] == "string"
     @test party_invite["properties"]["time"]["format"] == "date-time"
 
     # ensure the generated PartyInvite schema aligns
     event_invite = schemas["EventInvite"]
     @test event_invite["type"] == "object"
-    @test_has_key_and_values event_invite "required" ["party", "times"]
+    @test values_present(event_invite, "required", ["party", "times"])
     @test event_invite["properties"]["times"]["type"] == "array"
     @test event_invite["properties"]["times"]["items"]["format"] == "date-time"
     @test event_invite["properties"]["times"]["items"]["type"] == "string"

--- a/test/autodoctests.jl
+++ b/test/autodoctests.jl
@@ -29,6 +29,16 @@ struct EventInvite
     times::Vector{DateTime}
 end
 
+@kwdef struct Album 
+    releaseyear::Int
+    artist::Person
+    collaborators::Union{Vector{Person}, Nothing}
+end
+
+@post "/album" function (req, album::Json{Album})
+    return album.payload;
+end
+
 @post "/party-invite" function(req, party::Json{PartyInvite})
     return text("added $(length(party.payload.party.guests)) guests")
 end
@@ -55,6 +65,12 @@ schemas = ctx.docs.schema["components"]["schemas"]
     @test haskey(schemas, "Car")
     @test haskey(schemas, "Person")
     @test haskey(schemas, "Party")
+    @test haskey(schemas, "Album")
+    
+    album = schemas["Album"]
+    @test values_present(album, "required", ["releaseyear","artist"])
+    # Nullable field should not be present in the required field list
+    @test value_absent(album, "required", "collaborators")
 
     # ensure the generated Car schema aligns
     car = schemas["Car"]
@@ -96,6 +112,5 @@ schemas = ctx.docs.schema["components"]["schemas"]
     @test event_invite["properties"]["times"]["items"]["example"] |> !isempty
 
 end 
-
 
 end

--- a/test/autodoctests.jl
+++ b/test/autodoctests.jl
@@ -79,6 +79,14 @@ schemas = ctx.docs.schema["components"]["schemas"]
 
     # Test that partial arrays are combined in output
     @test values_present(merged, "required", ["field1", "field2"])
+
+    # When merging primitive vectors choose the latest instead of merging them
+    obj = Dict("required" => ["field1","field1","field2"])
+    obj = Dict("required" => ["field1","field2","field2"])
+    merged = Oxygen.AutoDoc.mergeschema(obj,obj)
+    @test value_count(obj, "required", "field1") == 1
+    # Verify that merge doesn't remove duplciate entries
+    @test value_count(obj, "required", "field2") == 2
 end
 
 @testset "schema gen tests" begin 

--- a/test/autodoctests.jl
+++ b/test/autodoctests.jl
@@ -58,35 +58,37 @@ schemas = ctx.docs.schema["components"]["schemas"]
     # ensure the generated Car schema aligns
     car = schemas["Car"]
     @test car["type"] == "object"
-    @test car["properties"]["name"]["required"] == true
+    @test haskey(car, "required") && all( x -> x in car["required"], ["name"])
     @test car["properties"]["name"]["type"] == "string"
 
     # ensure the generated Person schema aligns
     person = schemas["Person"]
     @test person["type"] == "object"
-    @test person["properties"]["name"]["required"] == true
+    @test haskey(person, "required") && all( x -> x in person["required"], ["name", "car"])
     @test person["properties"]["name"]["type"] == "string"
     @test person["properties"]["car"]["\$ref"] == "#/components/schemas/Car"
 
     # ensure the generated Party schema aligns
     party = schemas["Party"]
+    # There should be no required key defined if no fields are required
+    @test !haskey(party, "required")
     @test party["type"] == "object"
-    @test party["properties"]["guests"]["required"] == false
     @test party["properties"]["guests"]["type"] == "array"
     @test party["properties"]["guests"]["items"]["\$ref"] == "#/components/schemas/Person"
     @test party["properties"]["guests"]["default"] == "[{\"name\":\"Alice\",\"car\":{\"name\":\"Toyota\"}},{\"name\":\"Bob\",\"car\":{\"name\":\"Honda\"}}]"
     
     # ensure the generated PartyInvite schema aligns
     party_invite = schemas["PartyInvite"]
+    # Properties without default vaules should be required
     @test party_invite["type"] == "object"
-    @test party_invite["properties"]["time"]["required"] == true
+    @test haskey(party_invite, "required") && all( x -> x in party_invite["required"], ["party", "time"])
     @test party_invite["properties"]["time"]["type"] == "string"
     @test party_invite["properties"]["time"]["format"] == "date-time"
 
     # ensure the generated PartyInvite schema aligns
     event_invite = schemas["EventInvite"]
     @test event_invite["type"] == "object"
-    @test event_invite["properties"]["times"]["required"] == true
+    @test haskey(event_invite, "required") && all( x -> x in event_invite["required"], ["party", "times"])
     @test event_invite["properties"]["times"]["type"] == "array"
     @test event_invite["properties"]["times"]["items"]["format"] == "date-time"
     @test event_invite["properties"]["times"]["items"]["type"] == "string"

--- a/test/autodoctests.jl
+++ b/test/autodoctests.jl
@@ -32,6 +32,8 @@ end
 @kwdef struct Album 
     releaseyear::Int
     artist::Person
+    remasteredyear::Union{Int,Nothing}
+    soundtech::Union{Person,Nothing}
     collaborators::Union{Vector{Person}, Nothing}
 end
 
@@ -69,7 +71,13 @@ schemas = ctx.docs.schema["components"]["schemas"]
     
     album = schemas["Album"]
     @test values_present(album, "required", ["releaseyear","artist"])
-    # Nullable field should not be present in the required field list
+    # Bug fix: vector of object following object first use missing in 1.7.1
+    @test has_property(album, "collaborators")
+    # Bug fix: object following initial use missing in 1.7.1
+    @test has_property(album, "soundtech")
+    # Feature: nullable primitive types should not be required
+    @test value_absent(album, "required", "remasteredyear")
+    # Nullable vector types should not be required
     @test value_absent(album, "required", "collaborators")
 
     # ensure the generated Car schema aligns

--- a/test/extensions/timezonetests.jl
+++ b/test/extensions/timezonetests.jl
@@ -7,6 +7,7 @@ using Dates
 using TimeZones
 using Oxygen; @oxidise
 using ..Constants
+using ..TestUtils
 
 # This is the default format given from JS when creating a new date and calling toISOString()
 @testset "UTC ISO 8601 String Parsing Test" begin
@@ -58,7 +59,7 @@ paths = ctx.docs.schema["paths"]
     # ensure the generated Car schema aligns
     time_payload = components["TimePayload"]
     @test time_payload["type"] == "object"
-    @test haskey(time_payload, "required") && all( x -> x in time_payload["required"], ["time"])
+    @test_has_key_and_values time_payload "required" ["time"]
     @test time_payload["properties"]["time"]["type"] == "string"
     @test time_payload["properties"]["time"]["format"] == "date-time"
 end

--- a/test/extensions/timezonetests.jl
+++ b/test/extensions/timezonetests.jl
@@ -59,7 +59,7 @@ paths = ctx.docs.schema["paths"]
     # ensure the generated Car schema aligns
     time_payload = components["TimePayload"]
     @test time_payload["type"] == "object"
-    @test_has_key_and_values time_payload "required" ["time"]
+    @test values_present(time_payload, "required", ["time"])
     @test time_payload["properties"]["time"]["type"] == "string"
     @test time_payload["properties"]["time"]["format"] == "date-time"
 end

--- a/test/extensions/timezonetests.jl
+++ b/test/extensions/timezonetests.jl
@@ -58,7 +58,7 @@ paths = ctx.docs.schema["paths"]
     # ensure the generated Car schema aligns
     time_payload = components["TimePayload"]
     @test time_payload["type"] == "object"
-    @test time_payload["properties"]["time"]["required"] == true
+    @test haskey(time_payload, "required") && all( x -> x in time_payload["required"], ["time"])
     @test time_payload["properties"]["time"]["type"] == "string"
     @test time_payload["properties"]["time"]["format"] == "date-time"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 module RunTests 
 
 include("constants.jl"); using .Constants
+include("test_utils.jl"); using .TestUtils
 
 #### Extension Tests ####
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,9 +1,10 @@
 module TestUtils
 using Test
 
+export has_property
 export values_present
 export value_absent
-export has_property
+export value_count
 
 """
     values_present(dict, key, values)
@@ -14,6 +15,17 @@ Collection may contain additional values.
 """
 function values_present(dict, key, values)
     return haskey(dict, key) && all(x -> x in dict[key], values)
+end
+
+"""
+    value_count(dict,key,value)
+Returns occurence count of value in collection specified by key
+"""
+function value_count(dict, key, value)
+    if(!haskey(dict,key))
+        return 0
+    end
+    return count(x -> x == value,dict[key])
 end
 
 """

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -3,6 +3,7 @@ using Test
 
 export values_present
 export value_absent
+export has_property
 
 """
     values_present(dict, key, values)
@@ -12,7 +13,7 @@ and all the passed values are found in that collection.
 Collection may contain additional values.
 """
 function values_present(dict, key, values)
-    return haskey(dict, key) && all( x -> x in dict[key], values)
+    return haskey(dict, key) && all(x -> x in dict[key], values)
 end
 
 """
@@ -22,10 +23,20 @@ Tests that specified value is not found in the collection referencecd
 by the key on the dict, or that key's value in Dict is missing.
 """
 function value_absent(dict, key, value)
-    if(!haskey(dict, key))
+    if (!haskey(dict, key))
         return true
     end
-    return !any( x -> x == value, dict[key])
+    return !any(x -> x == value, dict[key])
+end
+
+"""
+    has_property(object, propertyName)
+
+Test that generated OpenAPI schema object defintion has the specified property.
+Safely check that `properties` key exists on dictionary first
+"""
+function has_property(object::Dict, propertyName::String)
+    return haskey(object, "properties") && haskey(object["properties"], propertyName)
 end
 
 end # module

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,20 +1,31 @@
 module TestUtils
 using Test
 
-export @test_has_key_and_values
+export values_present
+export value_absent
 
 """
-    test_has_key_and_values(dict, key, values)
+    values_present(dict, key, values)
 
-Asserts that the passed dictionary both safely contains the specified key, and the value
-of that field is a collection which contains all of the passed values. 
-It may contain more additional values.
+Asserts that the passed dictionary both safely contains the specified key, 
+and all the passed values are found in that collection. 
+Collection may contain additional values.
 """
-macro test_has_key_and_values(dict, key, values)
-    esc(quote
-        @test haskey($dict, $key)
-        @test all( x -> x in $dict[$key], $values)
-    end)
+function values_present(dict, key, values)
+    return haskey(dict, key) && all( x -> x in dict[key], values)
+end
+
+"""
+    value_absent(dict, key, value)
+
+Tests that specified value is not found in the collection referencecd
+by the key on the dict, or that key's value in Dict is missing.
+"""
+function value_absent(dict, key, value)
+    if(!haskey(dict, key))
+        return true
+    end
+    return !any( x -> x == value, dict[key])
 end
 
 end # module

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -11,13 +11,10 @@ of that field is a collection which contains all of the passed values.
 It may contain more additional values.
 """
 macro test_has_key_and_values(dict, key, values)
-    quote
-        local keyVal = $(esc(key))
-        local dictVal = $(esc(dict))
-        local testValues = $(esc(values))
-        @test haskey(dictVal, keyVal)
-        @test all( x -> x in dictVal[keyVal], testValues)
-    end
+    esc(quote
+        @test haskey($dict, $key)
+        @test all( x -> x in $dict[$key], $values)
+    end)
 end
 
 end # module

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,23 @@
+module TestUtils
+using Test
+
+export @test_has_key_and_values
+
+"""
+    test_has_key_and_values(dict, key, values)
+
+Asserts that the passed dictionary both safely contains the specified key, and the value
+of that field is a collection which contains all of the passed values. 
+It may contain more additional values.
+"""
+macro test_has_key_and_values(dict, key, values)
+    quote
+        local keyVal = $(esc(key))
+        local dictVal = $(esc(dict))
+        local testValues = $(esc(values))
+        @test haskey(dictVal, keyVal)
+        @test all( x -> x in dictVal[keyVal], testValues)
+    end
+end
+
+end # module


### PR DESCRIPTION
**Note:** This PR builds on the work in open [PR 253 ](https://github.com/OxygenFramework/Oxygen.jl/pull/253).  I try to avoid this where possible, but the code is related.

Issues addressed:
1. Fix: After the first occurrence of a custom struct as a field in a struct, no further fields referencing that object would be serialized (they are missing from output object).
2. New: Adds support for nullable fields defined as `::Union{T, Missing}` or `::Union{T,Nothing}`.  Documentation updated to reference this.

Tests added to prove support of both of the above.

Appreciate annoying to include both feature (nullable fields) and fixes in same PR.  Can separate if needed, but also trying to be efficient with time.