### PR TITLE
Improve safety when pushing to metric history

### DIFF
--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -23,7 +23,11 @@ struct TimeseriesRecord
 end
 
 function push_history(history::History, transaction::HTTPTransaction)
-    pushfirst!(history, transaction)
+    try
+        pushfirst!(history, transaction)
+    catch error
+        @warn "Failed to push transaction into our history: $error"
+    end
 end
 
 function get_history(history::History) :: Vector{HTTPTransaction}


### PR DESCRIPTION
Added try-catch block around pushfirst!() call with a warn() call. This prevents us from throwing a 500 even after a request is handled sucessfully