### PR TITLE
Fix: Restore response schema return type handling and improve OpenAPI.jl integration

### DIFF
--- a/src/errors.jl
+++ b/src/errors.jl
@@ -6,10 +6,18 @@ export ValidationError
 # This is used by the Extractors.jl module to signal that a validation error has occurred
 struct ValidationError <: Exception
     msg::String
+    cause::Union{Nothing, Exception}
+
+    ValidationError(msg::String) = new(msg, nothing)
+    ValidationError(msg::String, cause::Exception) = new(msg, cause)
 end
 
 function Base.showerror(io::IO, e::ValidationError)
     print(io, "Validation Error: $(e.msg)")
+    if !isnothing(e.cause)
+        print(io, "\nCaused by: ")
+        showerror(io, e.cause)
+    end
 end
 
 end

--- a/src/extractors.jl
+++ b/src/extractors.jl
@@ -107,8 +107,12 @@ which is caught and results with a 400 status code.
 function safe_extract(f::Function, param::Param{U}) :: T where {T, U <: Extractor{T}} 
     try 
         return f()
-    catch
-        throw(ValidationError("Failed to serialize data for | parameter: $(param.name) | extractor: $U | type: $T"))
+    catch e
+        if e isa ValidationError
+            throw(e)
+        end
+        # If the function fails, we throw a ValidationError with the parameter name and type
+        throw(ValidationError("Failed to serialize data for | parameter: $(param.name) | extractor: $U | type: $T", e))
     end
 end
 


### PR DESCRIPTION
**Linked Issues:**

* Closes #263
* Closes #264

**Summary of Changes:**
This PR includes two related but logically distinct improvements:

1. **Regression Fix for Response Schema Handling (#263):**

   * Restores the previously removed logic that handled the `returntype` of the response schema.
   * Ensures that downstream OpenAPI specs remain accurate and consistent with function return types.

2. **Improved Error Propagation in Type Creation (#264):**

   * Enhances integration with `OpenAPI.jl` by propagating the original exception when parameter type creation fails.
   * Provides clearer diagnostics during schema validation, avoiding error swallowing and easing debugging.

**Motivation:**

* The removal of return type handling broke compatibility with tools relying on the response schema (e.g., auto-doc generation or validation layers).
* Silent failures during parameter validation obscure the root cause and complicate issue tracing.

**Impact:**

* OpenAPI consumers will regain access to correct response schemas.
* Improved transparency and traceability when parameter type creation fails.

**Notes for Reviewers:**

* The two changes are logically grouped for this release due to their shared context in OpenAPI schema handling.
* Please pay attention to the error-wrapping logic to ensure no new regressions are introduced.
