### PR TITLE
CompatHelper: bump compat for DataStructures to 0.19, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,7 +37,7 @@ WGLMakieExt = ["WGLMakie", "Bonito"]
 [compat]
 Bonito = "^4"
 CairoMakie = "^0.13"
-DataStructures = "^0.18.15"
+DataStructures = "^0.18.15, 0.19"
 Dates = "^1"
 HTTP = "^1.8"
 JSON3 = "^1.9"


### PR DESCRIPTION
This pull request changes the compat entry for the `DataStructures` package from `^0.18.15` to `^0.18.15, 0.19`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.