### PR TITLE
CompatHelper: bump compat for WGLMakie in [weakdeps] to 0.13, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,7 @@ Statistics = "^1"
 StructTypes = "^1"
 Suppressor = "^0.2.6"
 TimeZones = "^1.20.0"
-WGLMakie = "^0.11"
+WGLMakie = "^0.11, 0.13"
 julia = "^1.10"
 
 [extras]


### PR DESCRIPTION
This pull request changes the compat entry for the `WGLMakie` package from `^0.11` to `^0.11, 0.13`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.