### PR TITLE
CompatHelper: bump compat for CairoMakie in [weakdeps] to 0.15, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ WGLMakieExt = ["WGLMakie", "Bonito"]
 
 [compat]
 Bonito = "^4"
-CairoMakie = "^0.13"
+CairoMakie = "^0.13, 0.15"
 DataStructures = "^0.18.15"
 Dates = "^1"
 HTTP = "^1.8"


### PR DESCRIPTION
This pull request changes the compat entry for the `CairoMakie` package from `^0.13` to `^0.13, 0.15`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.